### PR TITLE
config(Polaris): Fetching DB creds from env

### DIFF
--- a/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
+++ b/extension/persistence/eclipselink/src/main/java/org/apache/polaris/extension/persistence/impl/eclipselink/PolarisEclipseLinkMetaStoreSessionImpl.java
@@ -20,6 +20,8 @@ package org.apache.polaris.extension.persistence.impl.eclipselink;
 
 import static org.eclipse.persistence.config.PersistenceUnitProperties.ECLIPSELINK_PERSISTENCE_XML;
 import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_URL;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_USER;
+import static org.eclipse.persistence.config.PersistenceUnitProperties.JDBC_PASSWORD;
 
 import com.google.common.base.Predicates;
 import jakarta.persistence.EntityManager;
@@ -176,6 +178,9 @@ public class PolarisEclipseLinkMetaStoreSessionImpl implements PolarisMetaStoreS
       if (properties.containsKey(JDBC_URL)) {
         properties.put(JDBC_URL, properties.get(JDBC_URL).replace("{realm}", realm));
       }
+      //Fivetran: Changes to retrieve username and password from environment variables
+      properties.put(JDBC_USER, System.getenv("POLARIS_DB_USER"));
+      properties.put(JDBC_PASSWORD, System.getenv("POLARIS_DB_PASSWORD"));
       properties.put(ECLIPSELINK_PERSISTENCE_XML, confFile);
 
       factory = Persistence.createEntityManagerFactory(persistenceUnitName, properties);


### PR DESCRIPTION
closes [T-832689](https://fivetran.height.app/T-832689)

# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

Changes to fetch Polaris DB Creds from env variables

<img width="1332" alt="image (1)" src="https://github.com/user-attachments/assets/5faefdd1-b086-4b90-9357-ce222143b89a">
<img width="1660" alt="image" src="https://github.com/user-attachments/assets/d9001cf0-7636-478e-a3ea-ccf324f18c72">


## Type of change

# How Has This Been Tested?
Tested these changes by running Polaris locally and retrieving the values from the environment

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas