### PR TITLE
tweak(polaris): Track fivetran request

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/tracing/TracingFilter.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/tracing/TracingFilter.java
@@ -90,7 +90,7 @@ public class TracingFilter implements Filter {
         span.setAttribute(ServerAttributes.SERVER_ADDRESS, httpRequest.getServerName());
         span.setAttribute(UrlAttributes.URL_SCHEME, httpRequest.getScheme());
         span.setAttribute(UrlAttributes.URL_PATH, httpRequest.getPathInfo());
-        span.setAttribute("polaris.client.id", httpRequest.getHeader("header.Polaris-Client-ID"));
+        span.setAttribute("polaris.client.id", httpRequest.getHeader("Polaris-Client-ID"));
 
         chain.doFilter(request, response);
       } finally {

--- a/polaris-service/src/main/java/org/apache/polaris/service/tracing/TracingFilter.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/tracing/TracingFilter.java
@@ -90,6 +90,7 @@ public class TracingFilter implements Filter {
         span.setAttribute(ServerAttributes.SERVER_ADDRESS, httpRequest.getServerName());
         span.setAttribute(UrlAttributes.URL_SCHEME, httpRequest.getScheme());
         span.setAttribute(UrlAttributes.URL_PATH, httpRequest.getPathInfo());
+        span.setAttribute("polaris.client.id", httpRequest.getHeader("header.Polaris-Client-ID"));
 
         chain.doFilter(request, response);
       } finally {


### PR DESCRIPTION
links [T-798983](https://fivetran.height.app/T-798983) 
From the Fivetran client side, it is expected to pass the client ID in the header. In Polaris, upon completing each request, the logging exporter will log the trace ID, span ID, and the Polaris client ID

This links the fivetran polair client id with the request's trace ID, allowing us to use this trace ID to filter the complete logs for a particular request.

More details - https://fivetran.height.app/T-798983#activityId=5d063a24-c375-4c9f-9656-c84e9c60a98c


`DEBUG [2024-11-27 19:44:46,429 - 76428 ] [pool-3-thread-10 - GET /api/management/v1/catalogs] [] o.a.p.s.a.a.PolarisCatalogsApi: Completed execution of listCatalogs API with status code 200 
INFO  [2024-11-27 19:44:46,431 - 76430 ] [pool-3-thread-10] [] i.o.e.l.LoggingSpanExporter: 'GET /api/management/v1/catalogs' : f0421e29cd075fd60697414dc1b018ba 0655322144018f1b SERVER [tracer: /api/management/v1/catalogs:] AttributesMap{data={server.address=localhost, url.path=/api/management/v1/catalogs, http.request.method=GET, polaris.client.id=hskdGSKJKHJ12hdlk7SGFDJ90JDFsbw, realm=default-realm, url.scheme=http}, capacity=128, totalAddedValues=6} 
[0:0:0:0:0:0:0:1] - root [27/Nov/2024:14:14:46 +0000] "GET /api/management/v1/catalogs HTTP/1.1" 200 15 "-" "PostmanRuntime/7.42.0" 26`


