### PR TITLE
fix(Polaris): Ignore metadata tables on tableExists() in Polaris

### DIFF
--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -219,10 +219,9 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
   @Override
   public boolean tableExists(TableIdentifier identifier) {
     // Since we only care about actual tables when we call tableExists() and not metadata tables, we
-    // override it and
-    // provide an implementation that does not rely on wrapping loadTable() in a try/catch as the
-    // parent class does.
-    // As a result, it will not conflict with metadata table names anymore.
+    // override it and provide an implementation that does not rely on wrapping loadTable() in a
+    // try/catch as the parent class does. As a result, it will not conflict with metadata table
+    // names anymore.
     // Upstream(kostas): https://github.com/apache/polaris/pull/1772
     if (isValidIdentifier(identifier)) {
       return newTableOps(identifier).current() != null;

--- a/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
+++ b/polaris-service/src/main/java/org/apache/polaris/service/catalog/BasePolarisCatalog.java
@@ -217,6 +217,20 @@ public class BasePolarisCatalog extends BaseMetastoreViewCatalog
   }
 
   @Override
+  public boolean tableExists(TableIdentifier identifier) {
+    // Since we only care about actual tables when we call tableExists() and not metadata tables, we
+    // override it and
+    // provide an implementation that does not rely on wrapping loadTable() in a try/catch as the
+    // parent class does.
+    // As a result, it will not conflict with metadata table names anymore.
+    // Upstream(kostas): https://github.com/apache/polaris/pull/1772
+    if (isValidIdentifier(identifier)) {
+      return newTableOps(identifier).current() != null;
+    }
+    return false;
+  }
+
+  @Override
   public void initialize(String name, Map<String, String> properties) {
     Preconditions.checkState(
         this.catalogName.equals(name),

--- a/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
+++ b/polaris-service/src/test/java/org/apache/polaris/service/catalog/PolarisRestCatalogIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
@@ -58,7 +59,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.responses.ErrorResponse;
-import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.types.Types;
 import org.apache.polaris.core.PolarisConfiguration;
 import org.apache.polaris.core.admin.model.AwsStorageConfigInfo;
@@ -1218,14 +1218,12 @@ public class PolarisRestCatalogIntegrationTest extends CatalogTests<RESTCatalog>
       restCatalog.createNamespace(ns);
     }
     restCatalog
-            .buildTable(
-                    TableIdentifier.of(ns, "history"),
-                    new Schema(
-                            List.of(
-                                    Types.NestedField.required(1, "id", Types.IntegerType.get()))))
-            .withSortOrder(SortOrder.unsorted())
-            .withPartitionSpec(PartitionSpec.unpartitioned())
-            .withProperty("stage-create", "true")
-            .create();
+        .buildTable(
+            TableIdentifier.of(ns, "history"),
+            new Schema(List.of(Types.NestedField.required(1, "id", Types.IntegerType.get()))))
+        .withSortOrder(SortOrder.unsorted())
+        .withPartitionSpec(PartitionSpec.unpartitioned())
+        .withProperty("stage-create", "true")
+        .create();
   }
 }


### PR DESCRIPTION
# Description

Each time that we check if a table exists, we only look into real tables and not metadata tables.
The default implementation of this method uses loadTable() and catches an exception if the table doesn't exist.
The problem is that loadTable also resolves metadata tables.

Fixes T-946151

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation update
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Deployed polaris in staging and tested against it.
- [x] Created unit test

**Test Configuration**:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] If adding new functionality, I have discussed my implementation with the community using the linked GitHub issue
